### PR TITLE
Development

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -57,6 +57,9 @@ public func configure(_ app: Application) async throws {
   )
 
   try migrations(app)
+  // 自动执行migrations，省去在命令行运行`swift run App migrate`，或编辑scheme的步骤
+  try await app.autoMigrate().get()
+  
   try routes(app)
   try services(app)
   try repositories(app)

--- a/Sources/App/migrations.swift
+++ b/Sources/App/migrations.swift
@@ -27,4 +27,7 @@ func migrations(_ app: Application) throws {
   // 通知
   app.migrations.add(CreateMessageInfo())
   app.migrations.add(CreateMessage())
+  
+  // 自动执行migrations，省去在命令行运行`swift run App migrate`，或编辑scheme的步骤
+  try app.autoMigrate().wait()
 }

--- a/Sources/App/migrations.swift
+++ b/Sources/App/migrations.swift
@@ -27,7 +27,4 @@ func migrations(_ app: Application) throws {
   // 通知
   app.migrations.add(CreateMessageInfo())
   app.migrations.add(CreateMessage())
-  
-  // 自动执行migrations，省去在命令行运行`swift run App migrate`，或编辑scheme的步骤
-  try app.autoMigrate().wait()
 }


### PR DESCRIPTION
configure.swift文件中，在`try migrations(app)`后面添加了`try await app.autoMigrate().get()`，以便在首次运行以及后续有新migrations添加后，运行app能够自动执行注册的migrations。